### PR TITLE
API: Remove legacy connection options.

### DIFF
--- a/src/hoc/withConnect.ts
+++ b/src/hoc/withConnect.ts
@@ -2,10 +2,7 @@ import mongoose from 'mongoose';
 
 const withConnect = (handler) => async (req, res) => {
     if (!mongoose.connection.readyState) {
-        mongoose.connect(process.env.MONGODB as string, {
-            useFindAndModify: false,
-            useCreateIndex: true
-        });
+        mongoose.connect(process.env.MONGODB as string);
     }
 
     return handler(req, res);


### PR DESCRIPTION
These have been removed from mongoose and were causing deployment errors (email spam).